### PR TITLE
Reapply  "Sso bypass""

### DIFF
--- a/check_url_safety
+++ b/check_url_safety
@@ -1,6 +1,7 @@
 #!/bin/env python3
 # -*- coding: utf-8 -*-
-""" check_url_safety - standalone script for calling checkrmote.check_url_safety
+"""
+ check_url_safety - standalone script for calling checkrmote.check_url_safety.
 """
 
 ## check_url_safety
@@ -28,7 +29,7 @@ import argparse
 from urllib.error import URLError
 from urllib.parse import urlparse
 
-from checkremote import check_url_safety
+from checkremote import check_url_safety, is_host_local_sso_bypass, UnsupportedResourceError
 
 # initialize authorized hosts with the hosts that the caller script
 # may access
@@ -44,31 +45,58 @@ def check_url_hostname(url=None):
     else:
         raise UnsupportedResourceError('hostname', url)
 
+def check_sso_bypass_header(url=None):
+    """
+    Checks that the hostname in a url requires a bypass header.
+    Returns the header name and value if succesful, raises
+    an UnsupportedResourceError exception otherwise
+    """
+
+    parsed_url = urlparse(url)
+    if parsed_url is None or parsed_url.hostname is None:
+        raise UnsupportedResourceError('hostname', url)
+
+    bp_header = is_host_local_sso_bypass(parsed_url.hostname)
+    if bp_header is None:
+        raise UnsupportedResourceError('hostname', url)
+
+    return bp_header
+
+
 def main():
     url = None
 
-    parser = argparse.ArgumentParser(description='Checks if a URL is safe for opening')
+    parser = argparse.ArgumentParser(description='Checks if a URL is safe for opening and if it needs a bypass header')
     parser.add_argument('-u', '--url', type=str, required=True,
                         help='url to be checked', default=None)
     parser.add_argument('-cf', '--conf', type=str, required=False,
                         help='configuration file', default=None)
+    parser.add_argument('-bh', '--bypass-header', required=False,
+                        help='output bypass_header', action='store_true',
+                        default=False)
 
     args = parser.parse_args()
     url = args.url
+    bypass_header = args.bypass_header
 
     if url is None:
         parser.print_help()
         sys.exit(-1)
 
     try:
-        kwargs = dict(config_file=args.conf)
-        check_url_safety(url, **{k: v for k, v in kwargs.items() if v is not None})
-        # the hostcheck.conf file should contain the IP@ of the servers
-        # you're authorized to access in your subnet. If you want to
-        # futher restrict access outside of your local subnet,
-        # uncomment the line below and update the hostcheck.conf file
-        #check_url_hostname(url)
-        rv = 0
+        if bypass_header:
+            bp_header = check_sso_bypass_header(url)
+            print(f"{bp_header['name']}: {bp_header['value']}")
+            rv = 0
+        else:
+            kwargs = dict(config_file=args.conf)
+            check_url_safety(url, **{k: v for k, v in kwargs.items() if v is not None})
+            # the hostcheck.conf file should contain the IP@ of the servers
+            # you're authorized to access in your subnet. If you want to
+            # futher restrict access outside of your local subnet,
+            # uncomment the line below and update the hostcheck.conf file
+            #check_url_hostname(url)
+            rv = 0
     except:
         rv = -1
 

--- a/checkremote.py
+++ b/checkremote.py
@@ -27,6 +27,10 @@
 #    are part of a subnet should be considered local. This is useful
 #    if you have IPv6 address that don't correspond to addresses that
 #    ipaddress or the system libraries don't considers as local.
+# 09/2024 J. Kahan;
+# *  Support configuration options to declare a set of local hosts
+#    than can bypass sso authentication as well as the header allowing
+#    to do so
 
 #
 # This module depends on the python standard library ipaddress module,
@@ -78,10 +82,20 @@ def parse_config(config_file=DEFAULT_CONFIG_FILE):
     """ reads local config for specific local subnets and local ip
     addresses.
 
-    Initializes the global variables 'local_subnets' and
-    'addr_local_exemptions'. Each one of these variables is a list made
+    Returns a dictionary with the parsed configuration organized with
+    the following keys:
+
+    'local_subnets'
+    'addr_local_exemptions',
+    'addr_sso_bypass',
+    'sso_bypass_header'
+
+    Each one of the first three entries is a list made
     with the the different values of the respective configuration file
-    sections converted to ipaddr objects.
+    sections converted to ipaddr objects. 'sso_bypass_header is a dictionary.
+
+    If the configuration file is missing a section, the value for the key
+    will be empty.
 
     See hostcheck.conf.dist for syntax of the configuration file"""
 
@@ -108,7 +122,32 @@ def parse_config(config_file=DEFAULT_CONFIG_FILE):
     else:
         addr_local_exemptions = []
 
-    return (local_subnets, addr_local_exemptions)
+    if parsed_config.has_section('addr_sso_bypass'):
+        addr_local_sso_bypass = parsed_config.getlist('addr_sso_bypass',
+                                                      'addr')
+        addr_local_sso_bypass = [ipaddress.ip_address(value) for value
+                                 in addr_local_sso_bypass]
+    else:
+        addr_local_sso_bypass = []
+
+    sso_bypass_header = {}
+    if (
+            parsed_config.has_section('sso_bypass_header')
+            and parsed_config.has_option('sso_bypass_header', 'name')
+            and parsed_config.has_option('sso_bypass_header', 'value')
+    ):
+
+        name = parsed_config.get('sso_bypass_header', 'name')
+        value = parsed_config.get('sso_bypass_header','value')
+
+        if name and value:
+            sso_bypass_header['name'] = name
+            sso_bypass_header['value'] = value
+
+    return { 'local_subnets' : local_subnets,
+             'addr_local_exemptions': addr_local_exemptions,
+             'addr_local_sso_bypass' : addr_local_sso_bypass,
+             'sso_bypass_header' : sso_bypass_header }
 
 def all_addrs(host):
     """Iterate over IPAddress objects associated with this hostname.
@@ -171,7 +210,7 @@ def is_addr_local(addr, local_subnets=None, addr_local_exemptions=None):
 
     return is_local
 
-def is_host_local(host, config_file=DEFAULT_CONFIG_FILE):
+def is_host_local(host, config_file=DEFAULT_CONFIG_FILE, config_parsed=None):
     """Test if a hostname has local IP addresses.
 
     This function checks every IP address associated with the given
@@ -185,7 +224,10 @@ def is_host_local(host, config_file=DEFAULT_CONFIG_FILE):
     """
 
     # check that output of parse_config returns a list if config_file doesn't exist
-    (local_subnets, addr_local_exemptions) =  parse_config(config_file)
+    if not config_parsed:
+        config_parsed = parse_config(config_file)
+    local_subnets = config_parsed['local_subnets']
+    addr_local_exemptions = config_parsed['addr_local_exemptions']
 
     addresses = list(all_addrs(host))
     local_count = \
@@ -222,16 +264,17 @@ def check_port(port, service, extra_ports=frozenset(), min_safe_port=1024):
             (port >= min_safe_port)):
         raise UnsupportedResourceError("port", port)
 
-def check_url_safety(url, schemes=frozenset(['http', 'https', 'ftp']),
+def check_url_safety(url, schemes=frozenset(['http', 'https']),
                      check_port_func=check_port,
-                     config_file=DEFAULT_CONFIG_FILE):
+                     config_file=DEFAULT_CONFIG_FILE,
+                     config_parsed=None):
     """Check if a URL points to an acceptable remote resource.
 
     The first argument is the URL to test.  It is considered safe if it
     passes all of the following tests:
     * The URL scheme is included in the schemes argument.  Acceptable
       schemes should be listed as all-lowercase strings.  By default,
-      http, https, and ftp are accepted.  If None, all schemes are accepted.
+      http and https are accepted.  If None, all schemes are accepted.
     * The URL port, if specified, is checked using check_port_func.  This
       function is passed two arguments: the port number, and the lowercase
       URL scheme.  The default is this module's check_port function.
@@ -246,8 +289,45 @@ def check_url_safety(url, schemes=frozenset(['http', 'https', 'ftp']),
         raise UnsupportedResourceError("scheme", url)
     if parsed_url.port is not None:
         check_port_func(parsed_url.port, parsed_url.scheme.lower())
-    if is_host_local(parsed_url.hostname, config_file):
+    if is_host_local(parsed_url.hostname, config_file, config_parsed):
         raise UnsupportedResourceError("address", url)
+
+def is_host_local_sso_bypass(host, config_file=DEFAULT_CONFIG_FILE, config_parsed=None):
+    """Test if a host requires an sso bypass header.
+
+    You may pass in an IP address string. The function will return
+    the bypass header name and value if the test is succesful,
+    None otherwise.
+    """
+    rv = None
+
+    # check that output of parse_config returns a list if config_file doesn't exist
+    if not config_parsed:
+        config_parsed = parse_config(config_file)
+    addr_local_sso_bypass = config_parsed['addr_local_sso_bypass']
+    sso_bypass_header = config_parsed['sso_bypass_header']
+
+    if addr_local_sso_bypass and sso_bypass_header:
+        addresses = list(all_addrs(host))
+        local_count = \
+            len([a for a in addresses if a in addr_local_sso_bypass])
+
+        if local_count > 0:
+            rv = sso_bypass_header
+
+    return rv
+
+def check_sso_bypass(url,
+                     config_file=DEFAULT_CONFIG_FILE,
+                     config_parsed=None):
+    """if the remote host is configured to do an sso bpyass,
+    the function then returns the sso bypass header name and value,
+    otherwise returns None.
+    """
+    parsed_url = urlparse(url)
+    rv = is_host_local_sso_bypass(parsed_url.hostname, config_file, config_parsed)
+
+    return rv
 
 class URLSafetyHandler(urlreq.BaseHandler):
     """urllib handler to safety check all URLs.
@@ -260,12 +340,15 @@ class URLSafetyHandler(urlreq.BaseHandler):
     Each time a request is passed through this handler, the check
     function will be called with the request URL as an argument.  It
     should raise an exception if the URL is unsafe to handle."""
-    def __init__(self, check_func=check_url_safety, config_file=DEFAULT_CONFIG_FILE):
+    def __init__(self, check_func=check_url_safety, config_file=DEFAULT_CONFIG_FILE,
+                 config_parsed=None):
         self.check_url = check_func
         self.config_file = config_file
+        self.config_parsed = config_parsed
 
     def default_open(self, req, *args, **kwargs):
-        self.check_url(req.get_full_url(), config_file=self.config_file)
+        self.check_url(req.get_full_url(), config_file=self.config_file,
+                       config_parsed=self.config_parsed)
 
 
 safe_url_opener = urlreq.build_opener(URLSafetyHandler(config_file=DEFAULT_CONFIG_FILE))
@@ -273,24 +356,14 @@ safe_url_opener = urlreq.build_opener(URLSafetyHandler(config_file=DEFAULT_CONFI
 if __name__ == '__main__':
     import itertools
     import tempfile
+    import atexit
+    import os
 
-    good_urls = ['http://www.w3.org/index.html',
-                 'https://w3.org:8080/Overview.html',
-                 'https://10.0.0.23/index.html',
-                 'https://[2001:0000:130F:0000:0000:09C0:876A:130B]/index.html']
-    bad_urls = ['file:///etc/passwd',
-                'rsync://w3.org/',
-                'http://www.w3.org:22/',
-                'http://localhost/server-status',
-                'http://localhost:8001/2012/pyRdfa/Overview.html',
-                'https://10.0.0.24/index.html',
-                'https://[2001:0000:130F:0000:0000:09C0:876A:130C]/index.html']
-    test_config_file = tempfile.NamedTemporaryFile(delete=True)
-    test_opener = urlreq.OpenerDirector()
-    test_opener.add_handler(URLSafetyHandler(config_file=test_config_file.name))
-    # the value after the function name says if the function accepts
-    # the config_file parameter
-    check_funcs = [(check_url_safety, True), (test_opener.open, False)]
+    def rmfile(filename):
+        try:
+            os.unlink(filename)
+        except:
+            pass
 
     def write_test_config(fp):
         fp.write(b"""
@@ -301,7 +374,17 @@ subnet = 2001:0000:130F:0000::/56
 
 [addr_local_exemptions]
 addr = 10.0.0.23
+addr = 93.184.215.14
 addr = 2001:0000:130F:0000:0000:09C0:876A:130B
+
+[addr_sso_bypass]
+addr = 10.0.0.23
+addr = 93.184.215.14
+addr = 2001:0000:130F:0000:0000:09C0:876A:130B
+
+[sso_bypass_header]
+name = Foo
+value = Bar
         """)
         fp.flush()
 
@@ -319,7 +402,29 @@ addr = 2001:0000:130F:0000:0000:09C0:876A:130B
             extra_args = {}
         return extra_args
 
+    good_urls = ['http://example.org/index.html',
+                 'http://10.0.0.23/index.html',
+                 'https://w3.org:8080/Overview.html',
+                 'https://10.0.0.23/index.html',
+                 'https://example.org/index.html',
+                 'https://[2001:0000:130F:0000:0000:09C0:876A:130B]/index.html']
+    bad_urls = ['file:///etc/passwd',
+                'rsync://w3.org/',
+                'http://www.w3.org:22/',
+                'http://localhost/server-status',
+                'http://localhost:8001/2012/pyRdfa/Overview.html',
+                'https://10.0.0.24/index.html',
+                'https://[2001:0000:130F:0000:0000:09C0:876A:130C]/index.html']
+
+    test_config_file = tempfile.NamedTemporaryFile(delete=False)
+    atexit.register(rmfile, test_config_file.name)
     write_test_config(test_config_file)
+
+    test_opener = urlreq.OpenerDirector()
+    test_opener.add_handler(URLSafetyHandler(config_file=test_config_file.name))
+    # the value after the function name says if the function accepts
+    # the config_file parameter
+    check_funcs = [(check_url_safety, True), (test_opener.open, False)]
 
     for host in ['127.0.0.1', '127.254.1.2', '10.1.2.3', '10.254.4.5',
                  '172.16.1.2', '172.31.4.5', '192.168.0.1', '192.168.254.5',
@@ -328,11 +433,29 @@ addr = 2001:0000:130F:0000:0000:09C0:876A:130B
                  '2001:0000:130F:0000:0000:09C0:876A:130C'
                  ]:
         assert is_host_local(host, test_config_file.name), f"local host {host} not recognized"
-    for host in ['4.2.2.1', '2a03::1', 'w3.org', 'www.w3.org',
-                 '10.0.0.23',
+
+    for host in ['4.2.2.1', '2a03::1', 'w3.org',
+                 'example.org',
                  '2001:0000:130F:0000:0000:09C0:876A:130B'
                  ]:
         assert not is_host_local(host, test_config_file.name), f"non-local host {host} misflagged"
+
+    for host in ['example.org',
+                 '10.0.0.23',
+                 '2001:0000:130F:0000:0000:09C0:876A:130B'
+                 ]:
+        assert is_host_local_sso_bypass(host, test_config_file.name), f"sso bypass host {host} not recognized"
+
+    for host in ['4.2.2.1', '2a03::1', 'w3.org',
+                 '10.0.0.24',
+                 '2001:0000:130F:0000:0000:09C0:876A:130C'
+                 ]:
+        assert not is_host_local_sso_bypass(host, test_config_file.name), f"non sso bypass host {host} misflagged"
+
+    sso_bypass_header = is_host_local_sso_bypass('example.org', test_config_file.name)
+    assert sso_bypass_header, f"sso bypass header is None"
+    assert sso_bypass_header['name'] == 'Foo', f"sso bypass header name, expected 'Foo' got {sso_bypass_header['name']}"
+    assert sso_bypass_header['value'] == 'Bar', f"sso bypass header value, expected 'Bar' got {sso_bypass_header['name']}"
 
     for url, check_func in itertools.product(good_urls, check_funcs):
         extra_args = prepare_extra_args(add_config_file=check_func[1],

--- a/http_auth.py
+++ b/http_auth.py
@@ -1,74 +1,335 @@
-import urllib.request
-import urllib.parse
-import urllib.error
-import os
+#!/usr/bin/env python3
+"""
+Classes for doing rule constrained HTTP requests. Used in conjunction
+with checkremote.py.
+
+Module originally written by Dan Conolly and subsequently maintained
+by Dominique Hazael-Massieu and Brett Smith (2002-2021)
+
+* 2024-10-02: J. Kahan
+  rewrote the module and updated to use OpenerDirector handlers, fix
+  security issues, and add a new configurable bypass header option.
+"""
+
+import urllib
+import sys
+import requests
+
+# cf https://github.com/w3c/py-http-handler/blob/master/checkremote.py
+from checkremote import( parse_config, check_url_safety,
+                         check_sso_bypass, UnsupportedResourceError )
+
+# cf https://github.com/w3c/py-http-handler/blob/master/surbl.py
+import surbl
 
 
-class ProtectedURLopener(urllib.request.FancyURLopener):
-    def __init__(self):
-        import surbl
-        urllib.request.FancyURLopener.__init__(self)
-        self.surblchecker = surbl.SurblChecker(
-            '/usr/local/share/surbl/two-level-tlds', '/usr/local/etc/surbl.whitelist')
+class ProtectedURLopener():
+    """
+    Expands urllib.open with handlers that apply rule constrains to
+    HTTP requests.
+    """
+    version = "W3C HTTP Proxy Auth URL Opener/1.2"
 
-    def open(self, url, data=None):
-        # cf https://github.com/w3c/py-http-handler/blob/master/checkremote.py
-        from checkremote import check_url_safety, UnsupportedResourceError
-        try:
-            check_url_safety(url)
-        except UnsupportedResourceError:
-            raise IOError(403, "Access to url '%s' is not allowed" % url)
-        if self.surblchecker.isMarkedAsSpam(url):
-            raise IOError(
-                403, "Access to url '%s' is not allowed as it is marked as spam in SURBL" % url)
-        return urllib.request.FancyURLopener.open(self, url, data)
+    class CheckUrl():
+        """
+        Interface to checkremote.py to avoid having to open and parse
+        the config file each time a request is redirected
+        """
+        def __init__(self):
+            self.config_parsed  = parse_config()
+            self.surblchecker = surbl.SurblChecker(
+                '/usr/local/share/surbl/two-level-tlds', '/usr/local/etc/surbl.whitelist')
+
+        def check_url_safety(self, url):
+            """
+            checks if a URL is safe to be opened using checkremote.py.
+            raises an exception if url is not safe.
+            """
+            try:
+                check_url_safety(url, config_parsed=self.config_parsed)
+            except UnsupportedResourceError:
+                raise OSError( 403, f"Access to url {url} is not allowed" )
+            if self.surblchecker.isMarkedAsSpam(url):
+                raise OSError(
+                    403,
+                    f"Access to url {url} is not allowed as it is marked as spam in SURBL")
+
+        def check_sso_bypass_header(self, req):
+            """
+            If the target url needs an sso bypass header, the function will
+            add it to the request; otherwise it will delete it if it's
+            part of the request headers.
+            The function receives a request object and returns the modified request object
+            """
+            url = req.full_url
+
+            sso_bypass_header = self.config_parsed['sso_bypass_header']
+            if not sso_bypass_header:
+                return req
+
+            add_header = check_sso_bypass(url, config_parsed=self.config_parsed)
+
+            sso_bypass_header_name = sso_bypass_header['name']
+            sso_bypass_header_value = sso_bypass_header['value']
+
+            # urllib converts header name to all lowercase
+            # except for the first letter
+            c14n_sso_bypass_header_name = sso_bypass_header_name.lower().capitalize()
+
+            if add_header:
+                # add sso header if missing in req
+                if not req.has_header( c14n_sso_bypass_header_name ):
+                    req.add_header(sso_bypass_header_name, sso_bypass_header_value)
+            else:
+                # remove sso header if it is part of req
+                if req.has_header( c14n_sso_bypass_header_name ):
+                    req.remove_header(sso_bypass_header_name)
+
+            return req
+
+
+    class HTTPSHandler(urllib.request.HTTPSHandler):
+        """
+        Extends https_open to check for url safety and
+        sso bypass headers.
+        """
+        def __init__(self, check_url, *args, **kwargs):
+            self.check_url = check_url
+            super().__init__(*args, **kwargs)
+
+        def https_open(self, req):
+            self.check_url.check_url_safety(req.full_url)
+            req = self.check_url.check_sso_bypass_header(req)
+            return super().https_open(req)
+
+
+    class HTTPHandler(urllib.request.HTTPHandler):
+        """
+        Extends http_open to check for url safety and
+        sso bypass headers.
+        """
+        def __init__(self, check_url, *args, **kwargs):
+            self.check_url = check_url
+            super().__init__(*args, **kwargs)
+
+        def http_open(self, req):
+            self.check_url.check_url_safety(req.full_url)
+            req = self.check_url.check_sso_bypass_header(req)
+            return super().http_open(req)
+
+
+    class HTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
+        """
+        Completes urllib with an HTTP 304 handler.
+        """
+
+        def http_error_304(self, *args, **kwargs):
+            """
+            handler for HTTP 304 as it is still missing in urllib.requests.py
+            We just generate an error message.
+            """
+            print('HTTP/1.1 304 Not Modified')
+
+
+    class HTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
+        """
+        Default error handler so we get an HTTP page showing the error
+        instead of a python stack dump.
+        """
+        def __init__(self, protected_url_opener_instance, *args, **kwargs):
+            self.protected_url_opener_instance = protected_url_opener_instance
+            super().__init__(*args, **kwargs)
+
+        def http_error_default(self, req, fp, code, msg, hdrs):
+            self.protected_url_opener_instance.set_error(repr(code) + " " + msg)
+            super().http_error_default(req, fp, code, msg, hdrs)
+
+
+    def __init__(self, *args, **kwargs):
+        """
+        Adds custom handlers to urllib.open
+        """
+
+        super().__init__(*args, **kwargs)
+
+        # temp storage for user defined headers. Will be processed
+        # when we call open()
+        self.headers = {}
+
+        # filled-up as needed by the default_http_handler
+        self.error = ""
+
+        check_url = self.CheckUrl()
+
+        # initialize and associate our handlers with the opener
+        #
+
+        # adds HTTP 304 handler
+        http_redirection_handler = self.HTTPRedirectHandler()
+
+        # will call checkhosts to do different checks on URLs and
+        # add / remove custom HTTP headers as needed
+        https_handler = self.HTTPSHandler(check_url)
+        http_handler = self.HTTPHandler(check_url)
+
+        # make it easy for the error handler to find the caller of the class
+        # to store a custom error message
+        http_default_error_handler = \
+            self.HTTPDefaultErrorHandler(protected_url_opener_instance = self)
+
+        handlers = [
+            urllib.request.UnknownHandler,
+            https_handler,
+            http_handler,
+            http_default_error_handler,
+            http_redirection_handler,
+            urllib.request.HTTPErrorProcessor ]
+
+        # create "opener" (OpenerDirector instance)
+        self.opener = urllib.request.OpenerDirector()
+
+        # and associate it with our handlers, no default handlers unless
+        # specified in the handlers list
+        for handler in handlers:
+            if callable(handler):
+                self.opener.add_handler(handler())
+            else:
+                self.opener.add_handler(handler)
+
+        # make all calls to urllib.request.urlopen use our opener.
+        urllib.request.install_opener(self.opener)
+
+    def set_error(self, error):
+        self.error = error
+
+    def add_header(self, header_name, header_value):
+        """
+        temporarily store headers as we won't get the request
+        object until we call open()
+        """
+        if header_name and header_value:
+            self.headers[header_name] = header_value
+
+    def open(self, url, *args, **kwargs):
+        """
+        Opens a URL using the opener director
+        """
+
+        # clear previous error if we're reusing the same opener
+        self.error = ""
+
+        req = urllib.request.Request(url, unverifiable=True)
+
+        if self.headers:
+            for header, value in self.headers.items():
+                req.add_header(header, value)
+
+        resp = urllib.request.urlopen( req,
+                                       #timeout in seconds
+                                       #comment this parameter to use the default
+                                       #system timeout for sockets
+                                       timeout=30,
+                                      )
+        return resp
 
 
 class ProxyAuthURLopener(ProtectedURLopener):
-    error = ""
-    version = "W3C HTTP Proxy Auth URL Opener/1.1"
+    """
+    Dummy class to provide for backward compatibility while updating existing
+    scripts to the consolidated parent class
+    """
+    pass
 
-    def http_error_default(self, url, fp, errcode, errmsg, headers):
-        self.error = repr(errcode) + " " + errmsg
-        return None
+def tests():
+    """
+    Small testsuite to ease module maintenance.
+    """
 
-    def http_error_304(self, uri, fp, errocode, errmsg, headers):
-        print('HTTP/1.1 304 Not Modified')
-        return None
+    def test_url(opener,  url):
+        """
+        opens a url and returns the response object or
+        an error message.
+        """
+        try:
+            resp = opener.open( url )
+        except urllib.error.HTTPError as e:
+            opener.error = f"HTTP Error {e.code} {e.reason}"
+            resp = None
+        except urllib.error.URLError as e:
+            # use this exp one instead of http.client in htmldiff
+            opener.error = f"URL error: {e.reason}"
+            resp = None
+        except OSError as e:
+            opener.error = f"I/O error: {e.errno} {e.strerror}"
+            resp = None
+        except ValueError as e:
+            opener.error = str(e)
+            resp = None
+        except AttributeError:  # ProtectedURLopener returned None.
+            pass                # There's already an error set.
 
-    def open_local_file(self, url):
-        self.error = "Local file URL not accepted"
-        return None
-
-    def _send_auth_challenge(self, scheme, url, realm, data=None):
-        if scheme not in ('http', 'https'):
-            return
-        if os.environ.get('HTTP_AUTHORIZATION'):
-            self.addheader('Authorization', os.environ['HTTP_AUTHORIZATION'])
-            if data is None:
-                return self.open(scheme + ':' + url)
-            else:
-                return self.open(scheme + ':' + url, data)
+        if resp is None:
+            error_msg = opener.error
         else:
-            global Page
-            print('Status: 401 Authorization Required')
-            print('WWW-Authenticate: Basic realm="%s"' % realm)
-            print('Connection: close')
-            Page = """<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>401 Authorization Required</title>
-</head>
-<body>
-<h1>Authorization Required</h1>
-<p>You need %s access to %s:%s to use this service.</p>
-""" % (realm, scheme, url)
-            return None
+            error_msg = None
 
-    def retry_https_basic_auth(self, url, realm, data=None):
-        # @@@ need to send challenge through https as needed
-        return self._send_auth_challenge("https", url, realm, data)
+        return (resp, error_msg)
 
-    def retry_http_basic_auth(self, url, realm, data=None):
-        return self._send_auth_challenge("http", url, realm, data)
+    opener = ProtectedURLopener()
+
+    # public, not-redirected url
+    url = 'https://www.w3.org/'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp.code == 200, 'expected code 200'
+    assert resp.url == url, "didn't open expected url"
+
+    # public redirect
+    url = 'https://www.w3.org/a.html'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp.code == 200, 'expected code 200'
+    assert resp.url == 'https://www.w3.org/A.html', 'no redirection to expected url'
+
+    # public 304
+    url = 'https://httpbin.org/status/304'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None
+    assert error_msg.startswith('HTTP Error 304 '), 'expected HTTP Error 304 '
+
+    # protected URI
+    url = 'https://httpbin.org/basic-auth/foo/bar'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('HTTP Error 401 '), 'expected HTTP Error 401'
+
+    # localfiles
+    url = 'file:///etc/debian_version'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('URL error: '), 'expected URL error'
+
+    url = '/etc/debian_version'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('unknown url type: '), 'expected unkown url type'
+
+    # data uri
+    url = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=='
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('URL error: '), 'expected URL error'
+
+    # invalid urls
+    url = 'https://doesnexist.com/'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('URL error: '), 'expected URL error'
+
+    url = 'https://doesnexist.comeonthisdomainnameisimaginary/'
+    (resp, error_msg) = test_url(opener, url)
+    assert resp is None, 'expected empty resp object'
+    assert error_msg.startswith('URL error: '), 'expected URL error'
+
+    print( '\nall tests completed\n' )
+
+if __name__ == '__main__':
+    tests()


### PR DESCRIPTION
- replaced deprecated FancyURLOpener with OpenerDirector handlers.

- security issue: url safety checks were only done against the first opened url, but not against others if that first url was redirected elsewhere

- new option to add a configurable bypass header

- removed basic auth code as we were not using it

- merged class ProxyAuthURLopener into ProtectedURLopener as there 
was no contemporary reason why they should be separated. ProxyAuthURLopener is still available, but it's a dummy class that acts as an alias for ProtectedURLopener, to be deprecated when we finish updating scripts that use this class.

- added testsuite to ease updating of the code